### PR TITLE
fix off_t problem(32 bit system)

### DIFF
--- a/ngx_http_aws_sigv4_utils.c
+++ b/ngx_http_aws_sigv4_utils.c
@@ -1,7 +1,7 @@
+#include "ngx_http_aws_sigv4_utils.h"
 #include <string.h>
 #include <openssl/sha.h>
 #include <openssl/hmac.h>
-#include "ngx_http_aws_sigv4_utils.h"
 
 #define AWS_SIGV4_AUTH_HEADER_NAME            "Authorization"
 #define AWS_SIGV4_SIGNING_ALGORITHM           "AWS4-HMAC-SHA256"


### PR DESCRIPTION
nginx define _FILE_OFFSET_BITS=64
https://github.com/nginx/nginx/blob/5eadaf69e394c030056e4190d86dae0262f8617c/src/os/unix/ngx_linux_config.h#L16
in ngx_linux_config.h, if string.h included before ngx headers, off_t will be 4 byte(32 bit platform). 

```c
// <features.h>
#if defined _FILE_OFFSET_BITS && _FILE_OFFSET_BITS == 64
# define __USE_FILE_OFFSET64	1
#endif
// <sys/types.h>
# ifndef __USE_FILE_OFFSET64
typedef __off_t off_t;
# else
typedef __off64_t off_t;
# endif
```

_sigv4_utils.c:  ngx_log_error will coredump , because log pointer next to sent(off_t) exactly, sent is 0.
https://github.com/nginx/nginx/blob/5eadaf69e394c030056e4190d86dae0262f8617c/src/core/ngx_connection.h#L136-L138
nginx header file need include in starting pos.